### PR TITLE
Fix the AltStore Repo

### DIFF
--- a/docs/altstore/p0tionsource.json
+++ b/docs/altstore/p0tionsource.json
@@ -1,7 +1,7 @@
 {
     "name": "p0tion",
     "identifier": "com.p0tion-Team.p0tion",
-    "sourceURL": "https://github.com/p0tion-Team/p0tion-site/edit/main/src/altstore/p0tionsource.json",
+    "sourceURL": "https://github.com/p0tion-Team/p0tion-site/raw/main/docs/altstore/p0tionsource.json",
     "apps": [
       {
         "name": "p0tion",
@@ -11,14 +11,14 @@
         "version": "0.0.1",
         "versionDate": "2021-2-19",
         "versionDescription": "Works on iOS 12-14.3, arm64e",
-        "downloadURL": "https://github.com/p0tion-Team/p0tion-site/raw/main/src/altstore/p0tion.ipa",
+        "downloadURL": "https://github.com/p0tion-Team/p0tion-site/raw/main/docs/altstore/p0tion.ipa",
         "localizedDescription": "Supporting iOS Versions: 12-14.3 on arm64e (arm64 eta s0n).\np0tion is the first ever semi-untethered jailbreak working on all devices through iOS 12 - 14.3! It comes with Sileo for a more modern jailbreak feel and will kick off iOS 14's jailbreaking era!",
-        "iconURL": "https://github.com/p0tion-Team/p0tion-site/blob/main/src/img/p0tion2.png",
+        "iconURL": "https://github.com/p0tion-Team/p0tion-site/raw/main/docs/img/placeholder.png",
         "tintColor": "D287F4",
         "size": 26463301,
         "beta": true,
         "screenshotURLs": [
-          "https://github.com/p0tion-Team/p0tion-site/blob/main/src/img/p0tion2.png",
+          "https://github.com/p0tion-Team/p0tion-site/raw/main/docs/img/p0tion2.png",
         ]
       }
     ],
@@ -28,8 +28,8 @@
         "identifier": "p0tion-beta-start",
         "caption": "Supports iOS 12-14.3",
         "tintColor": "D287F4",
-        "imageURL": "https://github.com/p0tion-Team/p0tion-site/blob/main/src/img/p0tion2.png",
-        "appID": "fill_in_later",
+        "imageURL": "https://github.com/p0tion-Team/p0tion-site/raw/main/docs/img/p0tion2.png",
+        "appID": "com.p0tion-Team.p0tion",
         "date": "2021-2-19",
         "notify": true
       },
@@ -38,7 +38,7 @@
         "identifier": "welcome-to-p0tion-repo",
         "caption": "p0tion is now on AltStore!",
         "tintColor": "D287F4",
-        "url": "https://github.com/p0tion-Team/p0tion-site/edit/main/src/altstore/p0tionsource.json",
+        "url": "https://github.com/p0tion-Team/p0tion-site/raw/main/docs/altstore/p0tionsource.json",
         "date": "2021-2-19T12:59:00-07:00",
         "notify": false
       }

--- a/docs/altstore/p0tionsource.json
+++ b/docs/altstore/p0tionsource.json
@@ -11,7 +11,7 @@
         "version": "0.0.1",
         "versionDate": "2021-2-19",
         "versionDescription": "Works on iOS 12-14.3, arm64e",
-        "downloadURL": "https://github.com/p0tion-Team/p0tion-site/raw/main/docs/altstore/p0tion.ipa",
+        "downloadURL": "https://github.com/p0tion-Team/p0tion-site/raw/main/docs/altstore/payload.ipa",
         "localizedDescription": "Supporting iOS Versions: 12-14.3 on arm64e (arm64 eta s0n).\np0tion is the first ever semi-untethered jailbreak working on all devices through iOS 12 - 14.3! It comes with Sileo for a more modern jailbreak feel and will kick off iOS 14's jailbreaking era!",
         "iconURL": "https://github.com/p0tion-Team/p0tion-site/raw/main/docs/img/placeholder.png",
         "tintColor": "D287F4",


### PR DESCRIPTION
Right now, all the images won't load and once you get the IPA up that wouldn't download and it might have trouble installing. I just changed most of the URLs and now everything should load correctly. Also, try to avoid naming .ipa files anything but Payload.ipa, I had some problems in the past with AltStore and that.